### PR TITLE
Correction text "Таҳририлаш" => "Таҳрирлаш"

### DIFF
--- a/framework/messages/uz-Cy/yii.php
+++ b/framework/messages/uz-Cy/yii.php
@@ -67,7 +67,7 @@ return [
     'Unknown alias: -{name}' => '',
     'Unknown filter attribute "{attribute}"' => '',
     'Unknown option: --{name}' => 'Ноаниқ танлов: --{name}',
-    'Update' => 'Таҳририлаш',
+    'Update' => 'Таҳрирлаш',
     'View' => 'Кўриш',
     'Yes' => 'Ҳа',
     'You are not allowed to perform this action.' => 'Сизга ушбу амални бажаришга руҳсат берилмаган.',


### PR DESCRIPTION
In Uzbek it is "Таҳрирлаш"  not  "Таҳририлаш"

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

